### PR TITLE
add path to install.packages() docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Requirements : A Windows|Linux|MacOSX platform with R (>= 4.1) installed.
 
 
 We recommend to install the package using the latest [release](https://github.com/fgcz/prolfqua/releases)
-Download the `prolfqua_X.Y.Z.tar.gz` from the [github release page](https://github.com/fgcz/prolfqua/releases). and then execute:
+Download the `prolfqua_X.Y.Z.tar.gz` from the [github release page](https://github.com/fgcz/prolfqua/releases) into your working directory. and then execute:
 
 ```
-install.packages("prolfqua_X.Y.Z.tar.gz",repos = NULL, type="source")
+install.packages("./prolfqua_X.Y.Z.tar.gz",repos = NULL, type="source")
 ```
 
 


### PR DESCRIPTION
Without this, I was getting an error "Error: failed to resolve remote 'prolfqua_1.2.5.tar.gz' -- failed to parse remote spec 'prolfqua_1.2.5.tar.gz'".  Adding the path to `install_packages()` fixed it.  Just thought others might be having the same problem, and it might help to share.